### PR TITLE
Incorrect scroll at the end of the page 

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -120,11 +120,10 @@ a:hover {
 
 footer {
   display: flex;
-  height: 320px;
   flex-wrap: wrap;
   margin-top: auto;
   background-color: #2d2e33;
-  padding: 30px 10%;
+  padding: 35px 150px 5px 150px;
 }
 
 .footer-col {
@@ -432,7 +431,7 @@ section {
 
 .my-work {
   height: 150px;
-  font-size: 120px;
+  font-size: 100px;
   font-family: 'Orbitron', sans-serif;
   padding-top: 50px;
   border-bottom: 1px solid black;
@@ -442,7 +441,7 @@ section {
 .studio {
   display: flex;
   justify-content: flex-end;
-  font-size: 120px;
+  font-size: 100px;
   font-family: 'Orbitron', sans-serif;
   padding-top: 80px;
   border-bottom: 1px solid black;
@@ -452,7 +451,7 @@ section {
 .about-me {
   display: flex;
   justify-content: flex-start;
-  font-size: 120px;
+  font-size: 100px;
   font-family: 'Orbitron', sans-serif;
   padding-top: 50px;
   border-bottom: 1px solid black;
@@ -664,10 +663,9 @@ span {
   border-top: 1px solid #FBF9EE;
   width: 100%;
   font-family: 'Orbitron', sans-serif;
-  font-size: 150px;
+  font-size: 100px;
   font-weight: bold;
   color: #FBF9EE;
-  margin-top: 18px;
 }
 
 .picture-popup {


### PR DESCRIPTION
In terms of this task has been done:
- fixed incorrect scrolling at the end of the page

Here's the result:

before:
<img width="1512" alt="before 4" src="https://github.com/smootny/gaweloft/assets/62600472/473e25a1-fc7b-444a-bff1-cd7f5f6b218d">

after:
<img width="1512" alt="after 4" src="https://github.com/smootny/gaweloft/assets/62600472/ccad6a42-5569-4244-a6a6-4b89a277fbf8">